### PR TITLE
feat: implement user currencies

### DIFF
--- a/src/Skylight.API/Game/Catalog/ICatalogTransaction.cs
+++ b/src/Skylight.API/Game/Catalog/ICatalogTransaction.cs
@@ -3,12 +3,14 @@ using System.Text.Json;
 using Skylight.API.Game.Badges;
 using Skylight.API.Game.Furniture.Floor;
 using Skylight.API.Game.Furniture.Wall;
+using Skylight.API.Game.Users;
 
 namespace Skylight.API.Game.Catalog;
 
 public interface ICatalogTransaction : IAsyncDisposable, IDisposable
 {
 	public DbTransaction Transaction { get; }
+	public IUser User { get; }
 
 	public string ExtraData { get; }
 
@@ -16,6 +18,8 @@ public interface ICatalogTransaction : IAsyncDisposable, IDisposable
 
 	public void AddFloorItem(IFloorFurniture furniture, JsonDocument? extraData);
 	public void AddWallItem(IWallFurniture furniture, JsonDocument? extraData);
+
+	public void DeductCurrency(string currency, int amount);
 
 	public Task CompleteAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Skylight.API/Game/Users/CurrencyKeys.cs
+++ b/src/Skylight.API/Game/Users/CurrencyKeys.cs
@@ -1,0 +1,9 @@
+namespace Skylight.API.Game.Users;
+
+public static class CurrencyKeys
+{
+	public const string Credits = "skylight:credits";
+	public const string Silver = "skylight:silver";
+
+	public static readonly IReadOnlyList<string> All = [CurrencyKeys.Credits, CurrencyKeys.Silver];
+}

--- a/src/Skylight.API/Game/Users/IUser.cs
+++ b/src/Skylight.API/Game/Users/IUser.cs
@@ -13,6 +13,7 @@ public interface IUser : IPacketSender
 	public IClient Client { get; }
 	public IUserSettings Settings { get; }
 	public IUserProfile Profile { get; }
+	public IUserCurrencies Currencies { get; }
 	public IInventory Inventory { get; }
 	public IRoomSession? RoomSession { get; }
 

--- a/src/Skylight.API/Game/Users/IUserCurrencies.cs
+++ b/src/Skylight.API/Game/Users/IUserCurrencies.cs
@@ -1,0 +1,7 @@
+namespace Skylight.API.Game.Users;
+
+public interface IUserCurrencies
+{
+	int GetBalance(string currencyKey);
+	void UpdateBalance(string currencyKey, int newBalance);
+}

--- a/src/Skylight.Domain/Users/UserCurrenciesEntity.cs
+++ b/src/Skylight.Domain/Users/UserCurrenciesEntity.cs
@@ -1,0 +1,10 @@
+namespace Skylight.Domain.Users;
+
+public class UserCurrenciesEntity
+{
+	public int UserId { get; set; }
+	public UserEntity? User { get; set; }
+
+	public string Currency { get; set; } = null!;
+	public int Balance { get; set; }
+}

--- a/src/Skylight.Domain/Users/UserEntity.cs
+++ b/src/Skylight.Domain/Users/UserEntity.cs
@@ -15,6 +15,7 @@ public class UserEntity
 
 	public DateTime LastOnline { get; set; }
 
+	public ICollection<UserCurrenciesEntity> Currencies { get; set; } = new List<UserCurrenciesEntity>();
 	public UserSettingsEntity? Settings { get; set; }
 
 	public List<FloorItemEntity>? FloorItems { get; set; }

--- a/src/Skylight.Infrastructure/BaseSkylightContext.cs
+++ b/src/Skylight.Infrastructure/BaseSkylightContext.cs
@@ -80,6 +80,7 @@ public abstract class BaseSkylightContext(DbContextOptions options) : DbContext(
 
 	public DbSet<UserEntity> Users { get; init; } = null!;
 
+	public DbSet<UserCurrenciesEntity> UserCurrencies { get; init; } = null!;
 	public DbSet<UserSettingsEntity> UserSettings { get; init; } = null!;
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -134,6 +135,7 @@ public abstract class BaseSkylightContext(DbContextOptions options) : DbContext(
 		modelBuilder.ApplyConfiguration(new SettingsEntityTypeConfiguration());
 
 		modelBuilder.ApplyConfiguration(new UserEntityTypeConfiguration());
+		modelBuilder.ApplyConfiguration(new UserCurrenciesEntityTypeConfiguration());
 		modelBuilder.ApplyConfiguration(new UserSettingsEntityTypeConfiguration());
 		modelBuilder.ApplyConfiguration(new UserWardrobeEntityTypeConfiguration());
 	}

--- a/src/Skylight.Infrastructure/EntityConfigurations/Users/UserCurrenciesEntityTypeConfiguration.cs
+++ b/src/Skylight.Infrastructure/EntityConfigurations/Users/UserCurrenciesEntityTypeConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Skylight.Domain.Users;
+
+namespace Skylight.Infrastructure.EntityConfigurations.Users;
+
+internal sealed class UserCurrenciesEntityTypeConfiguration
+	: IEntityTypeConfiguration<UserCurrenciesEntity>
+{
+	public void Configure(EntityTypeBuilder<UserCurrenciesEntity> builder)
+	{
+		builder.ToTable(name: "user_currencies", tableBuilder => tableBuilder
+				.HasCheckConstraint(name: "ck_user_currencies_balance_non_negative", sql: "\"balance\" >= 0"));
+
+		builder.HasKey(e => new { e.UserId, e.Currency })
+			.HasName("pk_user_currencies");
+
+		builder.HasOne(e => e.User)
+			.WithMany(u => u.Currencies)
+			.HasForeignKey(e => e.UserId)
+			.OnDelete(DeleteBehavior.Cascade)
+			.HasConstraintName("fk_user_currencies_user");
+
+		builder.Property(e => e.Currency)
+			.IsRequired()
+			.HasMaxLength(100);
+
+		builder.Property(e => e.Balance)
+			.IsRequired()
+			.HasColumnType("integer")
+			.HasDefaultValue(0);
+	}
+}

--- a/src/Skylight.Infrastructure/Migrations/20250515201809_AddUserCurrenciesTable.cs
+++ b/src/Skylight.Infrastructure/Migrations/20250515201809_AddUserCurrenciesTable.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Skylight.Infrastructure.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddUserCurrenciesTable : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.CreateTable(
+				name: "user_currencies",
+				columns: table => new
+				{
+					user_id = table.Column<int>(type: "integer", nullable: false),
+					currency = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+					balance = table.Column<int>(type: "integer", nullable: false, defaultValue: 0)
+				},
+				constraints: table =>
+				{
+					table.PrimaryKey("pk_user_currencies", x => new { x.user_id, x.currency });
+					table.CheckConstraint("ck_user_currencies_balance_non_negative", "\"balance\" >= 0");
+					table.ForeignKey(
+						name: "fk_user_currencies_user",
+						column: x => x.user_id,
+						principalTable: "users",
+						principalColumn: "id",
+						onDelete: ReferentialAction.Cascade);
+				});
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropTable(name: "user_currencies");
+		}
+	}
+}

--- a/src/Skylight.Server/Game/Communication/Purse/GetCreditsInfoPacketHandler.cs
+++ b/src/Skylight.Server/Game/Communication/Purse/GetCreditsInfoPacketHandler.cs
@@ -12,6 +12,7 @@ internal sealed class GetCreditsInfoPacketHandler<T> : UserPacketHandler<T>
 {
 	internal override void Handle(IUser user, in T packet)
 	{
-		user.SendAsync(new CreditBalanceOutgoingPacket(999999));
+		int creditsBalance = user.Currencies.GetBalance(CurrencyKeys.Credits);
+		user.SendAsync(new CreditBalanceOutgoingPacket((int)creditsBalance));
 	}
 }

--- a/src/Skylight.Server/Game/Users/Authentication/UserAuthentication.cs
+++ b/src/Skylight.Server/Game/Users/Authentication/UserAuthentication.cs
@@ -78,8 +78,9 @@ internal sealed class UserAuthentication(RedisConnector redis, IDbContextFactory
 
 		await using SkylightContext dbContext = await this.dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
+		UserCurrencies userCurrencies = UserCurrencies.FromDatabase(profile.Id, dbContext, cancellationToken);
 		UserSettingsEntity? userSettings = await dbContext.UserSettings.FirstOrDefaultAsync(s => s.UserId == profile.Id, cancellationToken).ConfigureAwait(false);
-		User user = new(this.roomManager, client, profile, new UserSettings(userSettings));
+		User user = new(this.roomManager, client, profile, userCurrencies, new UserSettings(userSettings));
 
 		await user.LoadAsync(dbContext, this.loadContext, cancellationToken).ConfigureAwait(false);
 

--- a/src/Skylight.Server/Game/Users/User.cs
+++ b/src/Skylight.Server/Game/Users/User.cs
@@ -22,11 +22,12 @@ internal sealed class User : IUser
 
 	public IClient Client { get; }
 	public IUserProfile Profile { get; }
+	public IUserCurrencies Currencies { get; }
 	public IUserSettings Settings { get; }
 
 	private RoomSession? roomSession;
 
-	public User(IRoomManager roomManager, IClient client, IUserProfile profile, IUserSettings settings)
+	public User(IRoomManager roomManager, IClient client, IUserProfile profile, IUserCurrencies currencies, IUserSettings settings)
 	{
 		this.roomManager = roomManager;
 
@@ -34,6 +35,7 @@ internal sealed class User : IUser
 
 		this.Client = client;
 		this.Profile = profile;
+		this.Currencies = currencies;
 		this.Settings = settings;
 	}
 

--- a/src/Skylight.Server/Game/Users/UserCurrencies.cs
+++ b/src/Skylight.Server/Game/Users/UserCurrencies.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+using Skylight.API.Game.Users;
+using Skylight.Infrastructure;
+
+namespace Skylight.Server.Game.Users;
+
+internal sealed class UserCurrencies(Dictionary<string, int> initialCurrencies) : IUserCurrencies
+{
+	private readonly ConcurrentDictionary<string, int> currencies = new(initialCurrencies);
+
+	public static UserCurrencies FromDatabase(int userId, SkylightContext db, CancellationToken ct)
+	{
+		Dictionary<string, int> dbDict = db.UserCurrencies
+			.Where(c => c.UserId == userId)
+			.ToDictionary(c => c.Currency, c => c.Balance);
+
+		Dictionary<string, int> merged = CurrencyKeys.All
+			.ToDictionary(k => k, k => dbDict.GetValueOrDefault(k, 0));
+
+		return new UserCurrencies(merged);
+	}
+
+	public int GetBalance(string currencyKey) => this.currencies.GetValueOrDefault(currencyKey, 0);
+
+	public void UpdateBalance(string currencyKey, int newBalance) => this.currencies.AddOrUpdate(currencyKey, newBalance, (key, existing) => newBalance);
+}


### PR DESCRIPTION
# ✨ Feature: User Currencies

## Summary  
Introduce a standalone **User Currencies** subsystem so we can persist and manage multiple in-game currencies per user (starting with **credits** and **silver**, but fully customizable).

---

## Motivation  
- **Stateful Economy**: Replace hard-coded or ephemeral balances with a real database-backed wallet.  
- **Flexibility**: Ship with **credits** & **silver** by default, but hotel owners can add or remove currencies (e.g. duckets, tickets, seasonal tokens) without touching the schema.  
- **Consistency**: Centralize currency keys to avoid magic strings and typos.

---

## Customizability
- Default currencies out of the box: credits & silver.
- To add or remove currencies, simply update `CurrencyKeys.All`—no schema changes needed.
- Hotel owners can define any number of currencies (e.g. `"skylight:activity_points/0" (duckets)`, `"custom:tickets"`, `"hubbo:seasonal_goldfish"`).
